### PR TITLE
merge latest development of pikpak manually

### DIFF
--- a/backend/pikpak/api/types.go
+++ b/backend/pikpak/api/types.go
@@ -1,13 +1,12 @@
 // Package api has type definitions for pikpak
 //
-// Converted from the API docs with help from https://mholt.github.io/json-to-go/
+// Manually obtained from the API responses using Browse Dev. Tool and https://mholt.github.io/json-to-go/
 package api
 
 import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -40,31 +39,37 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 
 // Types of things in Item
 const (
-	KindOfFolder      = "drive#folder"
-	KindOfFile        = "drive#file"
-	KindOfFileList    = "drive#fileList"
-	KindOfResumable   = "drive#resumable"
-	ThumbnaleSizeS    = "SIZE_SMALL"
-	ThumbnaleSizeM    = "SIZE_MEDIUM"
-	ThumbnaleSizeL    = "SIZE_LARGE"
-	PhaseTypeComplete = "PHASE_TYPE_COMPLETE"
-	PhaseTypeRunning  = "PHASE_TYPE_RUNNING"
-	PhaseTypeError    = "PHASE_TYPE_ERROR"
-	ListLimit         = 100
+	KindOfFolder        = "drive#folder"
+	KindOfFile          = "drive#file"
+	KindOfFileList      = "drive#fileList"
+	KindOfResumable     = "drive#resumable"
+	KindOfForm          = "drive#form"
+	ThumbnailSizeS      = "SIZE_SMALL"
+	ThumbnailSizeM      = "SIZE_MEDIUM"
+	ThumbnailSizeL      = "SIZE_LARGE"
+	PhaseTypeComplete   = "PHASE_TYPE_COMPLETE"
+	PhaseTypeRunning    = "PHASE_TYPE_RUNNING"
+	PhaseTypeError      = "PHASE_TYPE_ERROR"
+	PhaseTypePending    = "PHASE_TYPE_PENDING"
+	UploadTypeForm      = "UPLOAD_TYPE_FORM"
+	UploadTypeResumable = "UPLOAD_TYPE_RESUMABLE"
+	ListLimit           = 100
 )
 
 // ------------------------------------------------------------
 
+// Error details api error from pikpak
 type Error struct {
 	Reason  string `json:"error"` // short description of the reason, e.g. "file_name_empty" "invalid_request"
 	Code    int    `json:"error_code"`
-	Url     string `json:"error_url,omitempty"`
+	URL     string `json:"error_url,omitempty"`
 	Message string `json:"error_description,omitempty"`
 	// can have either of `error_details` or `details``
 	ErrorDetails []*ErrorDetails `json:"error_details,omitempty"`
 	Details      []*ErrorDetails `json:"details,omitempty"`
 }
 
+// ErrorDetails contains further details of api error
 type ErrorDetails struct {
 	Type     string `json:"@type,omitempty"`
 	Reason   string `json:"reason,omitempty"`
@@ -91,14 +96,22 @@ var _ error = (*Error)(nil)
 
 // ------------------------------------------------------------
 
+// Filters contains parameters for filters when listing.
+//
+// possible operators
+// * in: a list of comma-separated string
+// * eq: "true" or "false"
+// * gt or lt: time format string, e.g. "2023-01-28T10:56:49.757+08:00"
 type Filters struct {
-	Phase   *map[string]string `json:"phase,omitempty"`
-	Trashed *map[string]bool   `json:"trashed,omitempty"`
-	Kind    *map[string]string `json:"kind,omitempty"`
-	Starred *map[string]bool   `json:"starred,omitempty"`
+	Phase        map[string]string `json:"phase,omitempty"`         // "in" or "eq"
+	Trashed      map[string]bool   `json:"trashed,omitempty"`       // "eq"
+	Kind         map[string]string `json:"kind,omitempty"`          // "eq"
+	Starred      map[string]bool   `json:"starred,omitempty"`       // "eq"
+	ModifiedTime map[string]string `json:"modified_time,omitempty"` // "gt" or "lt"
 }
 
-func (f *Filters) Set(field, value string) {
+// Set sets filter values using field name, operator and corresponding value
+func (f *Filters) Set(field, operator, value string) {
 	if value == "" {
 		// UNSET for empty values
 		return
@@ -106,34 +119,33 @@ func (f *Filters) Set(field, value string) {
 	r := reflect.ValueOf(f)
 	fd := reflect.Indirect(r).FieldByName(field)
 	if v, err := strconv.ParseBool(value); err == nil {
-		fd.Set(reflect.ValueOf(&map[string]bool{"eq": v}))
+		fd.Set(reflect.ValueOf(map[string]bool{operator: v}))
 	} else {
-		if len(strings.Split(value, ",")) > 1 {
-			fd.Set(reflect.ValueOf(&map[string]string{"in": value}))
-		} else {
-			fd.Set(reflect.ValueOf(&map[string]string{"eq": value}))
-		}
+		fd.Set(reflect.ValueOf(map[string]string{operator: value}))
 	}
 }
 
 // ------------------------------------------------------------
 // Common Elements
 
+// Link contains a download URL for opening files
 type Link struct {
-	Url    string `json:"url"`
+	URL    string `json:"url"`
 	Token  string `json:"token"`
 	Expire Time   `json:"expire"`
 	Type   string `json:"type,omitempty"`
 }
 
-type Url struct {
+// URL is a basic form of URL
+type URL struct {
 	Kind string `json:"kind,omitempty"` // e.g. "upload#url"
-	Url  string `json:"url,omitempty"`
+	URL  string `json:"url,omitempty"`
 }
 
 // ------------------------------------------------------------
 // Base Elements
 
+// FileList contains a list of File elements
 type FileList struct {
 	Kind            string  `json:"kind,omitempty"` // drive#fileList
 	Files           []*File `json:"files,omitempty"`
@@ -142,52 +154,67 @@ type FileList struct {
 	VersionOutdated bool    `json:"version_outdated,omitempty"`
 }
 
+// File is a basic element representing a single file object
+//
+// There are two types of download links,
+// 1) one from api.WebContentLink or api.Links.ApplicationOctetStream.Url and
+// 2) the other from api.Medias[].Link.Url.
+// Empirically, 2) is less restrictive to multiple concurrent range-requests
+// for a single file, i.e. supports for higher `--multi-thread-streams=N`.
+// However, it is not generally applicable as it is only for meadia.
 type File struct {
-	Kind              string      `json:"kind,omitempty"` // "drive#file"
-	Id                string      `json:"id,omitempty"`
-	ParentId          string      `json:"parent_id,omitempty"`
-	Name              string      `json:"name,omitempty"`
-	UserId            string      `json:"user_id,omitempty"`
-	Size              int64       `json:"size,omitempty,string"`
-	Revision          int         `json:"revision,omitempty,string"`
-	FileExtension     string      `json:"file_extension,omitempty"`
-	MimeType          string      `json:"mime_type,omitempty"`
-	Starred           bool        `json:"starred,omitempty"`
-	WebContentLink    string      `json:"web_content_link,omitempty"`
-	CreatedTime       Time        `json:"created_time,omitempty"`
-	ModifiedTime      Time        `json:"modified_time,omitempty"`
-	IconLink          string      `json:"icon_link,omitempty"`
-	ThumbnailLink     string      `json:"thumbnail_link,omitempty"`
-	Md5Checksum       string      `json:"md5_checksum,omitempty"`
-	Hash              string      `json:"hash,omitempty"` // sha1 but NOT a valid file hash.
-	Links             *FileLinks  `json:"links,omitempty"`
-	Phase             string      `json:"phase,omitempty"`
-	Audit             *FileAudit  `json:"audit,omitempty"`
-	Medias            []*Media    `json:"medias,omitempty"`
-	Trashed           bool        `json:"trashed,omitempty"`
-	DeleteTime        Time        `json:"delete_time,omitempty"`
-	OriginalUrl       string      `json:"original_url,omitempty"`
-	Params            *FileParams `json:"params,omitempty"`
-	OriginalFileIndex int         `json:"original_file_index,omitempty"` // TODO
-	Space             string      `json:"space,omitempty"`
-	Apps              []*FileApp  `json:"apps,omitempty"`
-	Writable          bool        `json:"writable,omitempty"`
-	FolderType        string      `json:"folder_type,omitempty"`
-	Collection        string      `json:"collection,omitempty"` // TODO
+	Apps              []*FileApp    `json:"apps,omitempty"`
+	Audit             *FileAudit    `json:"audit,omitempty"`
+	Collection        string        `json:"collection,omitempty"` // TODO
+	CreatedTime       Time          `json:"created_time,omitempty"`
+	DeleteTime        Time          `json:"delete_time,omitempty"`
+	FileCategory      string        `json:"file_category,omitempty"`
+	FileExtension     string        `json:"file_extension,omitempty"`
+	FolderType        string        `json:"folder_type,omitempty"`
+	Hash              string        `json:"hash,omitempty"` // sha1 but NOT a valid file hash. looks like a torrent hash
+	IconLink          string        `json:"icon_link,omitempty"`
+	ID                string        `json:"id,omitempty"`
+	Kind              string        `json:"kind,omitempty"` // "drive#file"
+	Links             *FileLinks    `json:"links,omitempty"`
+	Md5Checksum       string        `json:"md5_checksum,omitempty"`
+	Medias            []*Media      `json:"medias,omitempty"`
+	MimeType          string        `json:"mime_type,omitempty"`
+	ModifiedTime      Time          `json:"modified_time,omitempty"` // updated when renamed or moved
+	Name              string        `json:"name,omitempty"`
+	OriginalFileIndex int           `json:"original_file_index,omitempty"` // TODO
+	OriginalURL       string        `json:"original_url,omitempty"`
+	Params            *FileParams   `json:"params,omitempty"`
+	ParentID          string        `json:"parent_id,omitempty"`
+	Phase             string        `json:"phase,omitempty"`
+	Revision          int           `json:"revision,omitempty,string"`
+	Size              int64         `json:"size,omitempty,string"`
+	SortName          string        `json:"sort_name,omitempty"`
+	Space             string        `json:"space,omitempty"`
+	SpellName         []interface{} `json:"spell_name,omitempty"` // TODO maybe list of something?
+	Starred           bool          `json:"starred,omitempty"`
+	ThumbnailLink     string        `json:"thumbnail_link,omitempty"`
+	Trashed           bool          `json:"trashed,omitempty"`
+	UserID            string        `json:"user_id,omitempty"`
+	UserModifiedTime  Time          `json:"user_modified_time,omitempty"`
+	WebContentLink    string        `json:"web_content_link,omitempty"`
+	Writable          bool          `json:"writable,omitempty"`
 }
 
+// FileLinks includes links to file at backend
 type FileLinks struct {
 	ApplicationOctetStream *Link `json:"application/octet-stream,omitempty"`
 }
 
+// FileAudit contains audit information for the file
 type FileAudit struct {
 	Status  string `json:"status,omitempty"` // "STATUS_OK"
 	Message string `json:"message,omitempty"`
 	Title   string `json:"title,omitempty"`
 }
 
+// Media contains info about supported version of media, e.g. original, transcoded, etc
 type Media struct {
-	MediaId   string `json:"media_id,omitempty"`
+	MediaID   string `json:"media_id,omitempty"`
 	MediaName string `json:"media_name,omitempty"`
 	Video     struct {
 		Height     int    `json:"height,omitempty"`
@@ -212,15 +239,17 @@ type Media struct {
 	Category       string        `json:"category,omitempty"`
 }
 
+// FileParams includes parameters for instant open
 type FileParams struct {
 	Duration     int64  `json:"duration,omitempty,string"` // in seconds
 	Height       int    `json:"height,omitempty,string"`
 	Platform     string `json:"platform,omitempty"` // "Upload"
 	PlatformIcon string `json:"platform_icon,omitempty"`
-	Url          string `json:"url,omitempty"`
+	URL          string `json:"url,omitempty"`
 	Width        int    `json:"width,omitempty,string"`
 }
 
+// FileApp includes parameters for instant open
 type FileApp struct {
 	ID            string        `json:"id,omitempty"`   // "decompress" for rar files
 	Name          string        `json:"name,omitempty"` // decompress" for rar files
@@ -242,28 +271,30 @@ type FileApp struct {
 
 // ------------------------------------------------------------
 
+// TaskList contains a list of Task elements
 type TaskList struct {
 	Tasks         []*Task `json:"tasks,omitempty"` // "drive#task"
 	NextPageToken string  `json:"next_page_token"`
 	ExpiresIn     int     `json:"expires_in,omitempty"`
 }
 
+// Task is a basic element representing a single task such as offline download and upload
 type Task struct {
 	Kind              string        `json:"kind,omitempty"` // "drive#task"
-	Id                string        `json:"id,omitempty"`   // task id?
+	ID                string        `json:"id,omitempty"`   // task id?
 	Name              string        `json:"name,omitempty"` // torrent name?
 	Type              string        `json:"type,omitempty"` // "offline"
-	UserId            string        `json:"user_id,omitempty"`
+	UserID            string        `json:"user_id,omitempty"`
 	Statuses          []interface{} `json:"statuses,omitempty"`    // TODO
 	StatusSize        int           `json:"status_size,omitempty"` // TODO
 	Params            *TaskParams   `json:"params,omitempty"`      // TODO
-	FileId            string        `json:"file_id,omitempty"`
+	FileID            string        `json:"file_id,omitempty"`
 	FileName          string        `json:"file_name,omitempty"`
 	FileSize          string        `json:"file_size,omitempty"`
 	Message           string        `json:"message,omitempty"` // e.g. "Saving"
 	CreatedTime       Time          `json:"created_time,omitempty"`
 	UpdatedTime       Time          `json:"updated_time,omitempty"`
-	ThirdTaskId       string        `json:"third_task_id,omitempty"` // TODO
+	ThirdTaskID       string        `json:"third_task_id,omitempty"` // TODO
 	Phase             string        `json:"phase,omitempty"`         // e.g. "PHASE_TYPE_RUNNING"
 	Progress          int           `json:"progress,omitempty"`
 	IconLink          string        `json:"icon_link,omitempty"`
@@ -272,21 +303,40 @@ type Task struct {
 	Space             string        `json:"space,omitempty"`
 }
 
+// TaskParams includes parameters informing status of Task
 type TaskParams struct {
 	Age          string `json:"age,omitempty"`
 	PredictSpeed string `json:"predict_speed,omitempty"`
 	PredictType  string `json:"predict_type,omitempty"`
-	Url          string `json:"url,omitempty"`
+	URL          string `json:"url,omitempty"`
 }
 
+// Form contains parameters for upload by multipart/form-data
+type Form struct {
+	Headers    struct{} `json:"headers"`
+	Kind       string   `json:"kind"`   // "drive#form"
+	Method     string   `json:"method"` // "POST"
+	MultiParts struct {
+		OSSAccessKeyID string `json:"OSSAccessKeyId"`
+		Signature      string `json:"Signature"`
+		Callback       string `json:"callback"`
+		Key            string `json:"key"`
+		Policy         string `json:"policy"`
+		XUserData      string `json:"x:user_data"`
+	} `json:"multi_parts"`
+	URL string `json:"url"`
+}
+
+// Resumable contains parameters for upload by resumable
 type Resumable struct {
 	Kind     string           `json:"kind,omitempty"`     // "drive#resumable"
 	Provider string           `json:"provider,omitempty"` // e.g. "PROVIDER_ALIYUN"
 	Params   *ResumableParams `json:"params,omitempty"`
 }
 
+// ResumableParams specifies resumable paramegers
 type ResumableParams struct {
-	AccessKeyId     string `json:"access_key_id,omitempty"`
+	AccessKeyID     string `json:"access_key_id,omitempty"`
 	AccessKeySecret string `json:"access_key_secret,omitempty"`
 	Bucket          string `json:"bucket,omitempty"`
 	Endpoint        string `json:"endpoint,omitempty"`
@@ -295,6 +345,7 @@ type ResumableParams struct {
 	SecurityToken   string `json:"security_token,omitempty"`
 }
 
+// FileInArchive is a basic element in archive
 type FileInArchive struct {
 	Index    int    `json:"index,omitempty"`
 	Filename string `json:"filename,omitempty"`
@@ -308,26 +359,24 @@ type FileInArchive struct {
 
 // ------------------------------------------------------------
 
+// NewFile is a response to RequestNewFile
 type NewFile struct {
-	UploadType string `json:"upload_type,omitempty"`
-	File       *File  `json:"file,omitempty"`
-	Task       *Task  `json:"task,omitempty"` // null in this case
-}
-
-type NewResumable struct {
-	UploadType string     `json:"upload_type,omitempty"` // "UPLOAD_TYPE_RESUMABLE"
-	Resumable  *Resumable `json:"resumable,omitempty"`
 	File       *File      `json:"file,omitempty"`
-	Task       *Task      `json:"task,omitempty"` // null in this case
+	Form       *Form      `json:"form,omitempty"`
+	Resumable  *Resumable `json:"resumable,omitempty"`
+	Task       *Task      `json:"task,omitempty"`        // null in this case
+	UploadType string     `json:"upload_type,omitempty"` // "UPLOAD_TYPE_FORM" or "UPLOAD_TYPE_RESUMABLE"
 }
 
+// NewTask is a response to RequestNewTask
 type NewTask struct {
 	UploadType string `json:"upload_type,omitempty"` // "UPLOAD_TYPE_URL"
 	File       *File  `json:"file,omitempty"`        // null in this case
 	Task       *Task  `json:"task,omitempty"`
-	Url        *Url   `json:"url,omitempty"` // {"kind": "upload#url"}
+	URL        *URL   `json:"url,omitempty"` // {"kind": "upload#url"}
 }
 
+// About informs drive status
 type About struct {
 	Kind      string `json:"kind,omitempty"` // "drive#about"
 	Quota     *Quota `json:"quota,omitempty"`
@@ -336,6 +385,7 @@ type About struct {
 	} `json:"quotas,omitempty"` // maybe []*Quota?
 }
 
+// Quota informs drive quota
 type Quota struct {
 	Kind           string `json:"kind,omitempty"`                  // "drive#quota"
 	Limit          int64  `json:"limit,omitempty,string"`          // limit in bytes
@@ -345,14 +395,18 @@ type Quota struct {
 	PlayTimesUsage string `json:"play_times_usage,omitempty"`      // maybe in seconds
 }
 
+// Share is a response to RequestShare
+//
 // used in PublicLink()
 type Share struct {
-	ShareId   string `json:"share_id,omitempty"`
-	ShareUrl  string `json:"share_url,omitempty"`
+	ShareID   string `json:"share_id,omitempty"`
+	ShareURL  string `json:"share_url,omitempty"`
 	PassCode  string `json:"pass_code,omitempty"`
 	ShareText string `json:"share_text,omitempty"`
 }
 
+// User contains user account information
+//
 // GET https://user.mypikpak.com/v1/user/me
 type User struct {
 	Sub               string          `json:"sub,omitempty"`       // userid for internal use
@@ -367,22 +421,25 @@ type User struct {
 	PasswordUpdatedAt Time            `json:"password_updated_at,omitempty"`
 }
 
+// UserProvider details third-party authentication
 type UserProvider struct {
-	Id             string `json:"id,omitempty"` // e.g. "google.com"
-	ProviderUserId string `json:"provider_user_id,omitempty"`
+	ID             string `json:"id,omitempty"` // e.g. "google.com"
+	ProviderUserID string `json:"provider_user_id,omitempty"`
 	Name           string `json:"name,omitempty"` // username
 }
 
+// DecompressResult is a response to RequestDecompress
 type DecompressResult struct {
 	Status       string `json:"status,omitempty"` // "OK"
 	StatusText   string `json:"status_text,omitempty"`
-	TaskId       string `json:"task_id,omitempty"`   // same as File.Id
+	TaskID       string `json:"task_id,omitempty"`   // same as File.Id
 	FilesNum     int    `json:"files_num,omitempty"` // number of files in archive
 	RedirectLink string `json:"redirect_link,omitempty"`
 }
 
 // ------------------------------------------------------------
 
+// RequestShare is to request for file share
 type RequestShare struct {
 	FileIds        []string `json:"file_ids,omitempty"`
 	ShareTo        string   `json:"share_to,omitempty"`         // "publiclink",
@@ -390,45 +447,43 @@ type RequestShare struct {
 	PassCodeOption string   `json:"pass_code_option,omitempty"` // "NOT_REQUIRED"
 }
 
+// RequestBatch is to request for batch actions
 type RequestBatch struct {
-	Ids []string           `json:"ids,omitempty"`
-	To  *map[string]string `json:"to,omitempty"`
+	Ids []string          `json:"ids,omitempty"`
+	To  map[string]string `json:"to,omitempty"`
 }
 
-// used for creating `drive#folder`
+// RequestNewFile is to request for creating a new `drive#folder` or `drive#file`
 type RequestNewFile struct {
-	Kind     string `json:"kind,omitempty"` // "drive#folder"
-	Name     string `json:"name,omitempty"`
-	ParentId string `json:"parent_id,omitempty"`
+	// always required
+	Kind       string `json:"kind"` // "drive#folder" or "drive#file"
+	Name       string `json:"name"`
+	ParentID   string `json:"parent_id"`
+	FolderType string `json:"folder_type"`
+	// only when uploading a new file
+	Hash       string            `json:"hash,omitempty"`      // sha1sum
+	Resumable  map[string]string `json:"resumable,omitempty"` // {"provider": "PROVIDER_ALIYUN"}
+	Size       int64             `json:"size,omitempty"`
+	UploadType string            `json:"upload_type,omitempty"` // "UPLOAD_TYPE_FORM" or "UPLOAD_TYPE_RESUMABLE"
 }
 
-// async request for preparing new resumable file upload
-type RequestNewResumable struct {
-	Kind        string             `json:"kind,omitempty"` // "drive#file"
-	Name        string             `json:"name,omitempty"`
-	ParentId    string             `json:"parent_id,omitempty"`
-	UploadType  string             `json:"upload_type,omitempty"` // "UPLOAD_TYPE_RESUMABLE"
-	Size        int64              `json:"size,omitempty"`
-	Hash        string             `json:"hash,omitempty"`        // sha1sum
-	ObjProvider *map[string]string `json:"objProvider,omitempty"` // {"provider": "UPLOAD_TYPE_UNKNOWN"}
-}
-
-// async request for a new task uploading (offline downloading) files by Urls
+// RequestNewTask is to request for creating a new task like offline downloads
 //
-// Name and ParentId can be left empty.
+// Name and ParentID can be left empty.
 type RequestNewTask struct {
 	Kind       string `json:"kind,omitempty"` // "drive#file"
 	Name       string `json:"name,omitempty"`
-	ParentId   string `json:"parent_id,omitempty"`
+	ParentID   string `json:"parent_id,omitempty"`
 	UploadType string `json:"upload_type,omitempty"` // "UPLOAD_TYPE_URL"
-	Url        *Url   `json:"url,omitempty"`         // {"url": downloadUrl}
+	URL        *URL   `json:"url,omitempty"`         // {"url": downloadUrl}
 	FolderType string `json:"folder_type,omitempty"` // "" if parent_id else "DOWNLOAD"
 }
 
+// RequestDecompress is to request for decompress of archive files
 type RequestDecompress struct {
 	Gcid          string           `json:"gcid,omitempty"`     // same as File.Hash
 	Password      string           `json:"password,omitempty"` // ""
-	FileId        string           `json:"file_id,omitempty"`
+	FileID        string           `json:"file_id,omitempty"`
 	Files         []*FileInArchive `json:"files,omitempty"` // can request selected files to be decompressed
 	DefaultParent bool             `json:"default_parent,omitempty"`
 }
@@ -437,11 +492,13 @@ type RequestDecompress struct {
 
 // NOT implemented YET
 
+// VIP includes subscription details about premium account
+//
 // GET https://api-drive.mypikpak.com/drive/v1/privilege/vip
 type VIP struct {
 	Result      string `json:"result,omitempty"` // "ACCEPTED"
 	Message     string `json:"message,omitempty"`
-	RedirectUri string `json:"redirect_uri,omitempty"`
+	RedirectURI string `json:"redirect_uri,omitempty"`
 	Data        struct {
 		Expire Time   `json:"expire,omitempty"`
 		Status string `json:"status,omitempty"`  // "invalid"
@@ -450,18 +507,21 @@ type VIP struct {
 	} `json:"data,omitempty"`
 }
 
+// RequestArchiveFileList is to request for a list of files in archive
+//
 // POST https://api-drive.mypikpak.com/decompress/v1/list
 type RequestArchiveFileList struct {
 	Gcid     string `json:"gcid,omitempty"`     // same as api.File.Hash
 	Path     string `json:"path,omitempty"`     // "" by default
 	Password string `json:"password,omitempty"` // "" by default
-	FileId   string `json:"file_id,omitempty"`
+	FileID   string `json:"file_id,omitempty"`
 }
 
+// ArchiveFileList is a response to RequestArchiveFileList
 type ArchiveFileList struct {
 	Status      string           `json:"status,omitempty"`       // "OK"
 	StatusText  string           `json:"status_text,omitempty"`  // ""
-	TaskId      string           `json:"task_id,omitempty"`      // ""
+	TaskID      string           `json:"task_id,omitempty"`      // ""
 	CurrentPath string           `json:"current_path,omitempty"` // ""
 	Title       string           `json:"title,omitempty"`
 	FileSize    int64            `json:"file_size,omitempty"`

--- a/backend/pikpak/helper.go
+++ b/backend/pikpak/helper.go
@@ -24,7 +24,7 @@ func (f *Fs) requestDecompress(ctx context.Context, file *api.File, password str
 	req := &api.RequestDecompress{
 		Gcid:          file.Hash,
 		Password:      password,
-		FileId:        file.Id,
+		FileID:        file.ID,
 		Files:         []*api.FileInArchive{},
 		DefaultParent: true,
 	}
@@ -96,21 +96,17 @@ func (f *Fs) requestNewTask(ctx context.Context, req *api.RequestNewTask) (info 
 }
 
 // requestNewFile requests a new api.NewFile and returns api.File
-func (f *Fs) requestNewFile(ctx context.Context, req *api.RequestNewFile) (info *api.File, err error) {
+func (f *Fs) requestNewFile(ctx context.Context, req *api.RequestNewFile) (info *api.NewFile, err error) {
 	opts := rest.Opts{
 		Method: "POST",
 		Path:   "/drive/v1/files",
 	}
-	var newFile api.NewFile
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
-		resp, err = f.srv.CallJSON(ctx, &opts, &req, &newFile)
+		resp, err = f.srv.CallJSON(ctx, &opts, &req, &info)
 		return f.shouldRetry(ctx, resp, err)
 	})
-	if err != nil {
-		return nil, err
-	}
-	return newFile.File, nil
+	return
 }
 
 // getFile gets api.File from API for the ID passed
@@ -127,6 +123,10 @@ func (f *Fs) getFile(ctx context.Context, ID string) (info *api.File, err error)
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, nil, &info)
+		if err == nil && info.Phase != api.PhaseTypeComplete {
+			// could be pending right after file is created/uploaded.
+			return true, nil
+		}
 		return f.shouldRetry(ctx, resp, err)
 	})
 	return
@@ -177,20 +177,6 @@ func (f *Fs) requestShare(ctx context.Context, req *api.RequestShare) (info *api
 	return
 }
 
-// requestNewResumable creates an resumable session for uploading the object
-func (f *Fs) requestNewResumable(ctx context.Context, req *api.RequestNewResumable) (info *api.NewResumable, err error) {
-	opts := rest.Opts{
-		Method: "POST",
-		Path:   "/drive/v1/files",
-	}
-	var resp *http.Response
-	err = f.pacer.Call(func() (bool, error) {
-		resp, err = f.srv.CallJSON(ctx, &opts, &req, &info)
-		return f.shouldRetry(ctx, resp, err)
-	})
-	return
-}
-
 // Read the sha1 of in returning a reader which will read the same contents
 //
 // The cleanup function should be called when out is finished with
@@ -223,7 +209,7 @@ func readSHA1(in io.Reader, size, threshold int64) (sha1sum string, out io.Reade
 			_ = os.Remove(tempFile.Name()) // delete the cache file after we are done - may be deleted already
 		}
 
-		// copy the ENTIRE file to disc and calculate the MD5 in the process
+		// copy the ENTIRE file to disc and calculate the SHA1 in the process
 		if _, err = io.Copy(tempFile, teeReader); err != nil {
 			return
 		}

--- a/backend/pikpak/mod.go
+++ b/backend/pikpak/mod.go
@@ -1,0 +1,55 @@
+package pikpak
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/rclone/rclone/fs"
+)
+
+// ------------------------------------------------------------
+
+// parseRootID parses RootID from path
+func parseRootID(s string) (rootID string, err error) {
+	re := regexp.MustCompile(`\{([^}]{5,})\}`)
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return "", fmt.Errorf("%s does not contain a valid id", s)
+	}
+	rootID = m[1]
+
+	if strings.HasPrefix(rootID, "http") {
+		// https://mypikpak.com/drive/all/{ID}
+		// https://mypikpak.com/drive/recent/{ID}
+		// https://mypikpak.com/s/{ID}
+		re := regexp.MustCompile(`\/drive\/(all|recent)(\/([A-Za-z0-9_-]{6,}))+\/?`)
+		if m := re.FindStringSubmatch(rootID); m != nil {
+			rootID = m[len(m)-1]
+			return
+		}
+	}
+	return
+}
+
+// get an id of file or directory
+func (f *Fs) getID(ctx context.Context, path string) (id string, err error) {
+	if id, _ := parseRootID(path); len(id) > 6 {
+		info, err := f.getFile(ctx, id)
+		if err != nil {
+			return "", fmt.Errorf("no such object with id %q: %w", id, err)
+		}
+		return info.ID, nil
+	}
+	path = strings.Trim(path, "/")
+	id, err = f.dirCache.FindDir(ctx, path, false)
+	if err != nil {
+		o, err := f.NewObject(ctx, path)
+		if err != nil {
+			return "", err
+		}
+		id = o.(fs.IDer).ID()
+	}
+	return id, nil
+}

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -302,6 +302,18 @@ backends:
  - backend:  "pcloud"
    remote:   "TestPcloud:"
    fastlist: true
+ - backend:  "pikpak"
+   remote:   "TestPikPak:"
+   fastlist: false
+   oneonly:  true
+   ignore:
+    #  fs/operations
+    - TestCheckSum
+    - TestHashSums/Md5
+    #  fs/sync
+    - TestSyncWithTrackRenames
+    # integration
+    - TestIntegration/FsMkdir/FsPutFiles/ObjectMimeType
  - backend:  "webdav"
    remote:   "TestWebdavNextcloud:"
    ignore:


### PR DESCRIPTION
## Important Changes

### 1. No restrictions to `MultiThreadStreams`

Previously, `--multi-thread-streams` was hard-coded to `1` to avoid a concurrent session limit for downloading a single file. However, it has now been removed and set to `4` by global default. As the total number of sessions is limited per user as well as per file, it is important to carefully control it using the combination of `--multi-thread-streams` and `--transfers`.

### 2. Improved upload features

- Fixed issue unable to upload files to drive root
- Skip hash calculation when `src` already has it
- Implement `uploadByForm` for small-sized files
- `uploadByResumable` now with context

## Misc

### Removed

* Remove hard-coded User-Agent
* Remove unimplemented `starred_only` in option field
* Remove unnecessary `MergeDirs()` and `PutUnchecked()`
* Remove unsupported `PutStream()`
* Remove `Trashed` field when using `rclone about` as not working

### Fixed/Improved

* Fixed default `config.ConfigEncoding`
* Fixed `Precision()` error when syncing
* Better handling of `shouldRetry()` by recognizing API error
* `rclone link` now supports expiry in days
* Better handling of zero-byte objects
* Updated client id/secret

### Development notes

* Added new fields in `api.File`
  * `file_category`, `spell_name`, `sort_name`, and `user_modified_time`
* Filter when listing
  * More explicit way of constructing filter string
  * Prepare to use new `modified_time` field in filter but not used currently
* Functions used for mod features into a separate file `mod.go`
* Used a new API method when `rclone cleanup` instead of `BatchDelete`
* Fixed errors reported by golangci-lint
* Stop using pointers to map
