### PR TITLE
115: use thumbnail URLs for image downloads

### DIFF
--- a/backend/115/api/types.go
+++ b/backend/115/api/types.go
@@ -270,6 +270,21 @@ type SizeInfo struct {
 	SizeFormat string  `json:"size_format"`
 }
 
+type Image struct {
+	URL       string   `json:"url,omitempty"`
+	AllURL    []string `json:"all_url,omitempty"`    // all resized versions
+	OriginURL string   `json:"origin_url,omitempty"` // original, untouched
+	SourceURL string   `json:"source_url,omitempty"` // cdn url expires in 900s
+	FileName  string   `json:"file_name,omitempty"`
+	FileSha1  string   `json:"file_sha1,omitempty"`
+	PickCode  string   `json:"pick_code,omitempty"`
+}
+
+type ImageInfo struct {
+	State bool   `json:"state,omitempty"`
+	Data  *Image `json:"data,omitempty"`
+}
+
 // ------------------------------------------------------------
 
 type DownloadURL struct {

--- a/backend/115/helper.go
+++ b/backend/115/helper.go
@@ -503,6 +503,30 @@ func (f *Fs) getStats(ctx context.Context, cid string) (info *api.FileStats, err
 	return
 }
 
+func (f *Fs) getImage(ctx context.Context, pickCode string) (img *api.Image, err error) {
+	params := url.Values{}
+	params.Set("pickcode", pickCode)
+	opts := rest.Opts{
+		Method:     "GET",
+		Path:       "/files/image",
+		Parameters: params,
+	}
+
+	var info *api.ImageInfo
+	var resp *http.Response
+	err = f.pacer.Call(func() (bool, error) {
+		resp, err = f.srv.CallJSON(ctx, &opts, nil, &info)
+		return shouldRetry(ctx, resp, info, err)
+	})
+	if err != nil {
+		return
+	} else if !info.State {
+		// return nil, fmt.Errorf("API Error: %s (%d)", info.Message, info.Code)
+		return nil, fmt.Errorf("API Error: ")
+	}
+	return info.Data, nil
+}
+
 // ------------------------------------------------------------
 
 // add offline download task for multiple urls


### PR DESCRIPTION
#### What is the purpose of this change?

The image and the List API offer some advantages for retrieving download URLs:

- Longer Expiry: Thumbnails obtained through this endpoint have a 1-hour expiry, which is longer than the standard 15-minute lifespan.
- Open Access: No cookies are required to access these thumbnails, simplifying the process.

However, it's important to note that these endpoints doesn't consistently return the original file, even when using the `size=0` parameter. Therefore, it's not a reliable alternative for downloading files.

Just leaving this for future reference!

#### Was the change discussed in an issue or in the forum before?

See #31
