### PR TITLE
115: handle `PartAlreadyExists` error during multipart uploads

### DIFF
--- a/backend/115/multipart.go
+++ b/backend/115/multipart.go
@@ -288,7 +288,7 @@ func (w *ossChunkWriter) WriteChunk(ctx context.Context, chunkNumber int32, read
 		return -1, err
 	}
 
-	ossPartNumber := int32(chunkNumber + 1)
+	ossPartNumber := chunkNumber + 1
 	var res *oss.UploadPartResult
 	err = w.f.pacer.Call(func() (bool, error) {
 		// Discover the size by seeking to the end


### PR DESCRIPTION
#### What is the purpose of this change?

Multipart uploads could fail if a part was uploaded multiple times due to retries or other issues. This commit adds a check to prevent adding duplicate parts to the uploaded parts list, resolving the `PartAlreadyExists` error.

#### Was the change discussed in an issue or in the forum before?

#32
