### PR TITLE
drive: retry partially empty ListR groups

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -2299,6 +2299,22 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		listRSlices{dirs, paths}.Sort()
 		var iErr error
 		foundItems := false
+		parentHits := make([]int, len(dirs))
+		addItem := func(parentIndex int, item *drive.File) bool {
+			remote := path.Join(paths[parentIndex], item.Name)
+			entry, err := f.itemToDirEntry(ctx, remote, item)
+			if err != nil {
+				iErr = err
+				return true
+			}
+
+			err = cb(entry)
+			if err != nil {
+				iErr = err
+				return true
+			}
+			return false
+		}
 		_, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 			// shared with me items have no parents when at the root
 			if f.opt.SharedWithMe && len(item.Parents) == 0 && len(paths) == 1 && paths[0] == "" {
@@ -2317,6 +2333,7 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 					// - shared with me items have no parents at the root
 					// - if using a root alias, e.g. "root" or "appDataFolder" the ID won't match
 					i = 0
+					parentHits[i]++
 					// items at root can have more than one parent so we need to put
 					// the item in just once.
 					earlyExit = true
@@ -2326,17 +2343,9 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 					if i == len(dirs) || dirs[i] != parent {
 						continue
 					}
+					parentHits[i]++
 				}
-				remote := path.Join(paths[i], item.Name)
-				entry, err := f.itemToDirEntry(ctx, remote, item)
-				if err != nil {
-					iErr = err
-					return true
-				}
-
-				err = cb(entry)
-				if err != nil {
-					iErr = err
+				if addItem(i, item) {
 					return true
 				}
 
@@ -2347,6 +2356,29 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 			}
 			return false
 		})
+		// Found items in the multi directory listing, but some
+		// directories had no entries. Retry those directories
+		// individually to work around a bug in google drive where
+		// "(A in parents) or (B in parents)" can return entries for
+		// some parents but miss others.
+		if f.opt.FastListBugFix && len(dirs) > 1 && foundItems && iErr == nil && err == nil {
+			relisted := 0
+			for i, hits := range parentHits {
+				if hits != 0 {
+					continue
+				}
+				relisted++
+				_, err = f.list(ctx, []string{dirs[i]}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+					return addItem(i, item)
+				})
+				if err != nil || iErr != nil {
+					break
+				}
+			}
+			if relisted > 0 {
+				fs.Debugf(f, "Recycled %d directories individually to work around partial empty result from multi listing (%d)", relisted, len(dirs))
+			}
+		}
 		// Found no items in more than one directory. Retry these as
 		// individual directories This is to work around a bug in google
 		// drive where (A in parents) or (B in parents) returns nothing


### PR DESCRIPTION
## Summary

This updates the Google Drive ListR fast-list bug workaround to handle a partial-empty result from grouped parent queries.

Google Drive can return entries for some parents in a grouped query such as `(A in parents) or (B in parents)`, while silently returning no entries for other parents in the same group. The existing `--drive-fast-list-bug-fix` workaround only handled the more obvious case where the whole grouped query returned no entries.

When this partial miss happens during VFS recursive refresh, the missing parent directories can be cached as empty even though listing those parent IDs individually returns their contents. This is especially visible with Drive shortcut folder trees that link to content in other drives.

## Changes

- Track per-parent hit counts during Drive `ListR` grouped listings.
- When `--drive-fast-list-bug-fix` is enabled and a grouped listing returns some entries but leaves some parents with zero hits, retry only those zero-hit parents individually.
- Feed retried entries through the existing ListR callback path so child directories continue through the normal recursive queue.
- Keep this behavior under the existing `fast_list_bug_fix` option rather than adding a new user-facing flag.

## Validation

- Ran `go test ./backend/drive`.
- Reproduced the issue against a Google Drive shortcut-heavy tree where an initial recursive VFS refresh left multiple first-level directories empty.
- Confirmed with debug instrumentation before this patch that grouped queries returned zero hits for specific parent IDs while individual queries for those same IDs returned entries.
- Verified this patch fills the previously empty directories during the first recursive refresh.

## Notes

This improves correctness for partial grouped-query misses. It may add individual list calls for truly empty directories in affected grouped listings, but only when the existing Drive fast-list bug workaround is enabled.